### PR TITLE
Update shake_animated_widget.dart

### DIFF
--- a/lib/widgets/shake_animated_widget.dart
+++ b/lib/widgets/shake_animated_widget.dart
@@ -61,7 +61,7 @@ class _State extends State<ShakeAnimatedWidget> with TickerProviderStateMixin {
     if (widget.enabled ?? false) {
       _animationController.repeat();
     } else {
-      _animationController.stop();
+      _animationController.reset();
     }
   }
 


### PR DESCRIPTION
little fix to reset the animation state, widget doesn't hang around with wrong angle anymore